### PR TITLE
added functionality to enable the mode 'output_replace'

### DIFF
--- a/helper/pagemod.php
+++ b/helper/pagemod.php
@@ -141,7 +141,7 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
         $this->replace_closing_tag = "<pagemod ".$replace_prefix."end_$template_section_id></pagemod>";
 
         //remove previous rendering (=replace mode) for this section-ID
-        $template = preg_replace('#'.preg_quote($this->replace_start_tag).'.+'.preg_quote($this->replace_closing_tag).'#is', '',$template);
+        $template = preg_replace('#'.preg_quote($this->replace_start_tag).'((?!\<pagemod ).)+'.preg_quote($this->replace_closing_tag).'#is', '',$template);
 
         return preg_replace_callback('/<pagemod (\w+)(?: (.+?))?>(.*?)<\/pagemod>/s', array($this, 'parsePagemod'), $template);
     }

--- a/helper/pagemod.php
+++ b/helper/pagemod.php
@@ -8,6 +8,10 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
 
     var $patterns;
     var $values;
+    var $replace_start_tag;
+    var $replace_closing_tag;
+    var $replace_prefix = 'render_';
+
     protected $template_section_id;
 
     /**
@@ -131,6 +135,14 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
      */
     protected function updatePage($template, $template_section_id) {
         $this->template_section_id = $template_section_id;
+
+        $replace_prefix = $this->replace_prefix;
+        $this->replace_start_tag = "<pagemod ".$replace_prefix."start_$template_section_id></pagemod>";
+        $this->replace_closing_tag = "<pagemod ".$replace_prefix."end_$template_section_id></pagemod>";
+
+        //remove previous rendering (=replace mode) for this section-ID
+        $template = preg_replace('#'.preg_quote($this->replace_start_tag).'.+'.preg_quote($this->replace_closing_tag).'#is', '',$template);
+
         return preg_replace_callback('/<pagemod (\w+)(?: (.+?))?>(.*?)<\/pagemod>/s', array($this, 'parsePagemod'), $template);
     }
 
@@ -147,13 +159,16 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
         $params_string = $matches[2];
         $contents      = $matches[3];
 
+        //rendered tags produced by the 'output_replace' mode can be skipped
+        if(preg_match('/^'.preg_quote($this->replace_prefix).'/',$id) == 1) return $full_text;
+
         // First parse the parameters
-        $output_before = true;
+        $pagemod_method = '';
         if($params_string) {
             $params = array_map('trim', explode(",", $params_string));
             foreach($params as $param) {
-                if($param === 'output_after') {
-                    $output_before = false;
+                if(preg_match('/output_(after|before|replace)/s', $param) == 1) {
+                    $pagemod_method = $param;
                 }
             }
         }
@@ -165,11 +180,17 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
             //replace bureacracy variables
             $output = $this->replace($output);
 
-            if($output_before) {
-                return $output . $full_text;
-            } else {
-                return $full_text . $output;
+            switch($pagemod_method){
+                case 'output_replace':
+                    return $full_text . "\n" .$this->replace_start_tag . $output . $this->replace_closing_tag;
+                case 'output_before':
+                    return $output . $full_text;
+                case 'output_after':
+                    return $full_text . $output;
+                default:
+                    return $full_text;
             }
+
         } else {
             return $full_text;
         }


### PR DESCRIPTION
added functionality to enable the mode 'output_replace' to have your <pagemod> with a specific 'section ID' replaced (instead of appended or prepended) on modification
