### PR TITLE
Update pagemod.php : Allow page names to be built using variable names

### DIFF
--- a/helper/pagemod.php
+++ b/helper/pagemod.php
@@ -32,6 +32,7 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
 
         //handle arguments
         $page_to_modify = array_shift($argv);
+        $page_to_modify = $this->replace($page_to_modify);
         if($page_to_modify === '_self') {
             # shortcut to modify the same page as the submitter
             $page_to_modify = $ID;


### PR DESCRIPTION
Current script does not allow to pass arguments to build a dynamical target page name. For instance `action pagemod my_ns:@@Foo@@ my_id` does not link to my_ns:my_page as Foo is a parameter passed to the form with a "my_page" value. Indeed, target page name is not parsed to replace included variables