### PR TITLE
allow to create a new page and apply templates

### DIFF
--- a/helper/pagemod.php
+++ b/helper/pagemod.php
@@ -51,7 +51,6 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
                     $template = io_readFile(wikiFN($argvTemp[3]));
                 }
                 saveWikiText($page_to_modify, $template, "create via form");
-                return false;
             }else {
                 msg(sprintf($this->getLang('e_pagenotexists'), html_wikilink($page_to_modify)), -1);
                 return false;

--- a/helper/pagemod.php
+++ b/helper/pagemod.php
@@ -29,6 +29,7 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
         $this->prepareLanguagePlaceholder();
         $this->prepareNoincludeReplacement();
         $this->prepareFieldReplacements($fields);
+        $argvTemp = $argv;
 
         //handle arguments
         $page_to_modify = array_shift($argv);
@@ -43,8 +44,18 @@ class helper_plugin_pagemod_pagemod extends helper_plugin_bureaucracy_action {
         $template_section_id = cleanID(array_shift($argv));
 
         if(!page_exists($page_to_modify)) {
-            msg(sprintf($this->getLang('e_pagenotexists'), html_wikilink($page_to_modify)), -1);
-            return false;
+            
+            if ($argvTemp[2] == "createPage"){
+                $template = " ";
+                if (count($argvTemp) >= 4){
+                    $template = io_readFile(wikiFN($argvTemp[3]));
+                }
+                saveWikiText($page_to_modify, $template, "create via form");
+                return false;
+            }else {
+                msg(sprintf($this->getLang('e_pagenotexists'), html_wikilink($page_to_modify)), -1);
+                return false;
+            }
         }
 
         // check auth


### PR DESCRIPTION
with this modification you can now create a new page and use template to fill content

i use this feature like that in my personal dokuwiki : 

```
<form>
textbox "Cible"
action pagemod pj:dossiers:@@Cible@@ add_rapport createPage pagetemplates:rapporttemplate
action pagemod pj:dossiers add_rapport

```

`createPage` is the first arg to indicate if you want create a new page if dosent exist 
`pagetemplates:rapporttemplate` is the second argument to indicate if you wante to fill your new page with a another page
